### PR TITLE
Modification of _sfit4_read_out.py in order to read the summary files of the SFIT4 Official Release

### DIFF
--- a/spyfit/io/_sfit4_read_out.py
+++ b/spyfit/io/_sfit4_read_out.py
@@ -22,9 +22,9 @@ HEADER_PATTERN = (r"\s*SFIT4:V(?P<sfit4_version>[0-9.]+)"
 def parse_header(line,ignore_case=False):
     """Parse the header line of an output file."""
     if ignore_case:
-        m = re.match(HEADER_PATTERN, line)
-    else:
         m = re.match(HEADER_PATTERN, line,re.IGNORECASE)
+    else:
+        m = re.match(HEADER_PATTERN, line)
     
     header = m.groupdict()
 

--- a/spyfit/io/_sfit4_read_out.py
+++ b/spyfit/io/_sfit4_read_out.py
@@ -20,7 +20,7 @@ HEADER_PATTERN = (r"\s*SFIT4:V(?P<sfit4_version>[0-9.]+)"
                   r"\s*(?P<description>.+)")
 
 
-def parse_header(line,ignore_case=False):
+def parse_header(line,ignore_case=True):
     """Parse the header line of an output file."""
     if ignore_case:
         m = re.match(HEADER_PATTERN, line,re.IGNORECASE)

--- a/spyfit/io/_sfit4_read_out.py
+++ b/spyfit/io/_sfit4_read_out.py
@@ -16,7 +16,7 @@ from .utils import expand_path, sanatize_var_name, eval_value
 
 
 HEADER_PATTERN = (r"\s*SFIT4:V(?P<sfit4_version>[0-9.]+)"
-                  r"[\w\s:-]*RUNTIME:(?P<runtime>[0-9:\-]+)"
+                  r"[\w\s.:-]*RUNTIME:(?P<runtime>[0-9:\-]+)"
                   r"\s*(?P<description>.+)")
 
 

--- a/spyfit/io/_sfit4_read_out.py
+++ b/spyfit/io/_sfit4_read_out.py
@@ -787,7 +787,7 @@ def read_solar_spectrum(filename, var_name='', wdim='spec_wn_solar'):
 
 def read_summary(filename, spdim='spectrum', wcoord='spec_wn',
                  scoord='spec_scan', bcoord='spec_band',
-                 bdim='band', sdim='scan'):
+                 bdim='band', sdim='scan',ignore_case_header=False):
     """
     Read retrieval summary in SFIT4 output ascii files.
 
@@ -820,7 +820,7 @@ def read_summary(filename, spdim='spectrum', wcoord='spec_wn',
 
     """
     with open(filename, 'r') as f:
-        header = parse_header(f.readline())
+        header = parse_header(f.readline(),ignore_case=ignore_case_header)
         global_attrs = header
         global_attrs['source'] = expand_path(filename)
 

--- a/spyfit/io/_sfit4_read_out.py
+++ b/spyfit/io/_sfit4_read_out.py
@@ -837,7 +837,7 @@ def read_summary(filename, spdim='spectrum', wcoord='spec_wn',
             header = f.readline().strip()
             if header not in spec_headers:
                 spec_headers.append(header)
-
+        global_attrs['spec_headers'] = spec_headers
         # retrieved gases
         _ = f.readline()
         n_gases = int(f.readline())

--- a/spyfit/io/_sfit4_read_out.py
+++ b/spyfit/io/_sfit4_read_out.py
@@ -19,9 +19,13 @@ HEADER_PATTERN = (r"\s*SFIT4:V(?P<sfit4_version>[0-9.]+)"
                   r"\s*(?P<description>.+)")
 
 
-def parse_header(line):
+def parse_header(line,ignore_case=False):
     """Parse the header line of an output file."""
-    m = re.match(HEADER_PATTERN, line)
+    if ignore_case:
+        m = re.match(HEADER_PATTERN, line)
+    else:
+        m = re.match(HEADER_PATTERN, line,re.IGNORECASE)
+    
     header = m.groupdict()
 
     runtime = datetime.datetime.strptime(header.pop('runtime'),

--- a/spyfit/io/_sfit4_read_out.py
+++ b/spyfit/io/_sfit4_read_out.py
@@ -9,6 +9,7 @@ import math
 import glob
 import warnings
 
+import packaging
 import numpy as np
 
 from .utils import expand_path, sanatize_var_name, eval_value
@@ -827,9 +828,7 @@ def read_summary(filename, spdim='spectrum', wcoord='spec_wn',
         variables = {}
         coords = {}
 
-        sfitversion = global_attrs['sfit4_version']
-        sfitversion = sfitversion.split('.')
-        sfitversion = float('{}.{}{}{}'.format(*sfitversion))
+        sfitversion = packaging.version.parse(global_attrs['sfit4_version'])
                
         # spectrum headers (assume same header for every band)
         _ = f.readline()
@@ -845,7 +844,7 @@ def read_summary(filename, spdim='spectrum', wcoord='spec_wn',
         _ = f.readline()
         for i in range(n_gases):
             cvals = [eval_value(s) for s in f.readline().split()]
-            if sfitversion > 0.944:
+            if sfitversion > packaging.version.parse('0.9.4.4'):
                 index, name, ret_prof, ifcell, atcol, rtcol = cvals
             else:
                 index, name, ret_prof, atcol, rtcol = cvals
@@ -858,7 +857,7 @@ def read_summary(filename, spdim='spectrum', wcoord='spec_wn',
         _ = f.readline()
         ickeys = ['index', 'wn_start', 'wn_end', 'wn_step',
                   'n_points', 'spec_opd_max', 'spec_fov']
-        if sfitversion > 0.944:
+        if sfitversion > packaging.version.parse('0.9.4.4'):
             snr_var = ['spec_snr_initial', 'spec_snr_eff','spec_snr_fit']
             jckeys = ['index'] + snr_var
         else:


### PR DESCRIPTION
The read_summary function is now able to read the new format of summary files (SFIT4 new release). it includes the new SNR outputs and the handling of the slightly different header.

The function is still able to read <V1 SFIT4 summary files as it reads the version in the header of the summary files